### PR TITLE
Computational domain can start at different place to 0

### DIFF
--- a/Cuda-CMM/examples/params-11-4nodes-reference-remapping.txt
+++ b/Cuda-CMM/examples/params-11-4nodes-reference-remapping.txt
@@ -11,9 +11,8 @@ grid_vort	=	2048
 final_time	=	1
 set_dt_by_steps	=	1
 steps_per_sec	=	512
-save_computational_num	=	2
-save_computational	=	{is_instant=0,time_start=0,time_end=0,time_step=0.5,var= ,conv=1}
-save_computational	=	{is_instant=0,time_start=0,time_end=0,time_step=0,var=,conv=0}
+save_computational_num	=	1
+save_computational	=	{is_instant=0,time_start=0,time_end=1,time_step=0.5,var= ,conv=1}
 mem_RAM_CPU_remaps	=	9000
 save_map_stack	=	0
 restart_time	=	0
@@ -31,8 +30,8 @@ molly_stencil	=	0
 freq_cut_psi	=	128
 skip_remapping	=	0
 save_sample_num	=	2
-save_sample	=	{is_instant=0,time_start=0,time_end=0,time_step=0,var= ,grid=2048}
-save_sample	=	{is_instant=1,time_start=1,var=Chi_b-W,grid=2048}
+save_sample	=	{is_instant=0,time_start=0,time_end=0,time_step=0,var= ,grid=1024}
+save_sample	=	{is_instant=0,time_start=0,time_end=1,time_step=1,var=Chi_b-W-Psi-U,grid=1024}
 scalar_name	=	circular_ring
 scalar_discrete	=	0
 save_zoom_num	=	0

--- a/Cuda-CMM/examples/params-11b-4nodes-reference-remapping.txt
+++ b/Cuda-CMM/examples/params-11b-4nodes-reference-remapping.txt
@@ -1,0 +1,42 @@
+CMM Parameter file
+param_version	=	3
+
+workspace	=	./
+simulation_type	=	cmm_euler_2d
+sim_name	=	11b-4nodes-reference-remapping
+grid_coarse	=	256
+grid_fine	=	512
+grid_psi	=	256
+grid_vort	=	512
+final_time	=	2
+set_dt_by_steps	=	1
+steps_per_sec	=	32
+save_computational_num	=	2
+save_computational	=	{is_instant=0,time_start=0,time_end=10000,time_step=0.5,var= ,conv=1}
+save_computational	=	{is_instant=0,time_start=0,time_end=10000,time_step=1,var=PartA_01-PartA_02,conv=1}
+mem_RAM_CPU_remaps	=	50
+save_map_stack	=	0
+restart_time	=	0
+verbose	=	3
+initial_condition	=	4_nodes
+initial_params	=	{0,0,0,0,0,0,0,0,0,0}
+initial_discrete	=	0
+incomp_threshold	=	0.00001
+map_epsilon	=	0.001
+time_integration	=	RK3
+lagrange_override	=	-1
+lagrange_init_higher_order	=	1
+map_update_order	=	4th
+molly_stencil	=	0
+freq_cut_psi	=	128
+skip_remapping	=	0
+save_sample_num	=	2
+save_sample	=	{is_instant=0,time_start=0,time_end=0,time_step=0,var= ,grid=256}
+save_sample	=	{is_instant=0,time_start=0,time_end=10000,time_step=1,var=W-Psi-U,grid=256}
+scalar_name	=	circular_ring
+scalar_discrete	=	0
+save_zoom_num	=	0
+forward_map	=	0
+particles_advected_num	=	2
+particles_advected	=	{num=1000,tau=0,seed=0,time_integration=RK3,init_name=uniform,init_time=0,init_param_1=3.141592653589793,init_param_2=3.141592653589793,init_param_3=6.283185307179586,init_param_4=6.283185307179586}
+particles_advected	=	{num=1000,tau=0.5,seed=0,time_integration=RK3,init_name=uniform,init_time=0,init_param_1=3.141592653589793,init_param_2=3.141592653589793,init_param_3=6.283185307179586,init_param_4=6.283185307179586}

--- a/Cuda-CMM/examples/readme.txt
+++ b/Cuda-CMM/examples/readme.txt
@@ -222,6 +222,7 @@ Remappings are enabled and a reference low-pass filter of 128 was used.
 The simulation takes up approximately 1GB of GPU RAM and 4GB of CPU RAM.
 Conservation is computed at beginning and every s-time, in addition the backwards map and vorticity is saved every s-time as well.
 
+Example 11b is the same but with coarser settings, this is for development tests to ensure corect outputs.
 
 
 *****   Example 12 - V100 run of shear layer flow   *****

--- a/Cuda-CMM/src/grid/cmm-grid2d.cu
+++ b/Cuda-CMM/src/grid/cmm-grid2d.cu
@@ -25,7 +25,7 @@ TCudaGrid2D::TCudaGrid2D (int NX, int NY, int NZ, double *bounds)
 	this->hy = (bounds[3] - bounds[2]) / (float)NY;
 	this->hz = (bounds[5] - bounds[4]) / (float)NZ;
 
-	for (int i_b = 0; i_b < 4; ++i_b) {
+	for (int i_b = 0; i_b < 6; ++i_b) {
 		this->bounds[i_b] = bounds[i_b];
 	}
 

--- a/Cuda-CMM/src/numerical/cmm-hermite.cu
+++ b/Cuda-CMM/src/numerical/cmm-hermite.cu
@@ -151,13 +151,13 @@ __device__ T device_hermite_mult_3D(T *H, T bX[], T bY[], T bZ[], int I[], long 
 template<typename T>
 __device__ void device_init_ind(int *I, T *dxy, T x, T y, TCudaGrid2D Grid) {
 	//cell index
-	int Ix0 = floor(x/Grid.hx); int Iy0 = floor(y/Grid.hy);
+	int Ix0 = floor((x-Grid.bounds[0])/Grid.hx); int Iy0 = floor((y-Grid.bounds[2])/Grid.hy);
 	int Ix1 = Ix0 + 1; int Iy1 = Iy0 + 1;
 
 	//dx, dy
-	dxy[0] = x/Grid.hx - Ix0; dxy[1] = y/Grid.hy - Iy0;
+	dxy[0] = (x-Grid.bounds[0])/Grid.hx - Ix0; dxy[1] = (y-Grid.bounds[2])/Grid.hy - Iy0;
 
-	// project into domain, < 0 check is needed as integer division rounds towards 0
+	// project into domain, < bounds[0/2] check is needed as integer division rounds towards 0
 	Ix0 -= (Ix0/Grid.NX - (Ix0 < 0))*Grid.NX; Iy0 -= (Iy0/Grid.NY - (Iy0 < 0))*Grid.NY;
 	Ix1 -= (Ix1/Grid.NX - (Ix1 < 0))*Grid.NX; Iy1 -= (Iy1/Grid.NY - (Iy1 < 0))*Grid.NY;
 
@@ -167,13 +167,17 @@ __device__ void device_init_ind(int *I, T *dxy, T x, T y, TCudaGrid2D Grid) {
 template<typename T>
 __device__ void device_init_ind(int *I, T *dxyz, T x, T y, T z, TCudaGrid2D Grid) {
 	//cell index
-	int Ix0 = floor(x/Grid.hx); int Iy0 = floor(y/Grid.hy); int Iz0 = floor(z/Grid.hz);
+	int Ix0 = floor((x-Grid.bounds[0])/Grid.hx);
+	int Iy0 = floor((y-Grid.bounds[2])/Grid.hy);
+	int Iz0 = floor((z-Grid.bounds[4])/Grid.hz);
 	int Ix1 = Ix0 + 1; int Iy1 = Iy0 + 1; int Iz1 = Iz0 + 1;
 
-	//dx, dy
-	dxyz[0] = x/Grid.hx - Ix0; dxyz[1] = y/Grid.hy - Iy0; dxyz[2] = z/Grid.hz - Iz0;
+	//dx, dy, dz
+	dxyz[0] = (x-Grid.bounds[0])/Grid.hx - Ix0;
+	dxyz[1] = (y-Grid.bounds[2])/Grid.hy - Iy0;
+	dxyz[1] = (z-Grid.bounds[4])/Grid.hz - Iz0;
 
-	// project into domain, < 0 check is needed as integer division rounds towards 0
+	// project into domain, < bounds[0/2] check is needed as integer division rounds towards 0
 	Ix0 -= (Ix0/Grid.NX - (Ix0 < 0))*Grid.NX; Iy0 -= (Iy0/Grid.NY - (Iy0 < 0))*Grid.NY; Iz0 -= (Iz0/Grid.NZ - (Iz0 < 0))*Grid.NZ;
 	Ix1 -= (Ix1/Grid.NX - (Ix1 < 0))*Grid.NX; Iy1 -= (Iy1/Grid.NY - (Iy1 < 0))*Grid.NY; Iz1 -= (Iz1/Grid.NZ - (Iz1 < 0))*Grid.NZ;
 
@@ -186,11 +190,11 @@ __device__ void device_init_ind(int *I, T *dxyz, T x, T y, T z, TCudaGrid2D Grid
 template<typename T>
 __device__ void device_init_ind_diff(int *I, int *I_w, T *dxy, T x, T y, TCudaGrid2D Grid) {
 	// cell index
-	int Ix0 = floor(x/Grid.hx); int Iy0 = floor(y/Grid.hy);
+	int Ix0 = floor((x-Grid.bounds[0])/Grid.hx); int Iy0 = floor((y-Grid.bounds[2])/Grid.hy);
 	int Ix1 = Ix0 + 1; int Iy1 = Iy0 + 1;
 
-	//dx, dy, distance to footpoints
-	dxy[0] = x/Grid.hx - Ix0; dxy[1] = y/Grid.hy - Iy0;
+	//dx, dy
+	dxy[0] = (x-Grid.bounds[0])/Grid.hx - Ix0; dxy[1] = (y-Grid.bounds[2])/Grid.hy - Iy0;
 
 	//warping, compute projection needed to map onto L.x/L.y domain, add 1 for negative values to accommodate sign
 	I_w[0] = Ix0/Grid.NX - (Ix0 < 0); I_w[1] = Iy0/Grid.NY - (Iy0 < 0);
@@ -205,11 +209,15 @@ __device__ void device_init_ind_diff(int *I, int *I_w, T *dxy, T x, T y, TCudaGr
 template<typename T>
 __device__ void device_init_ind_diff(int *I, int *I_w, T *dxyz, T x, T y, T z, TCudaGrid2D Grid) {
 	// cell index
-	int Ix0 = floor(x/Grid.hx); int Iy0 = floor(y/Grid.hy); int Iz0 = floor(z/Grid.hz);
+	int Ix0 = floor((x-Grid.bounds[0])/Grid.hx);
+	int Iy0 = floor((y-Grid.bounds[2])/Grid.hy);
+	int Iz0 = floor((z-Grid.bounds[4])/Grid.hz);
 	int Ix1 = Ix0 + 1; int Iy1 = Iy0 + 1; int Iz1 = Iz0 + 1;
 
 	//dx, dy
-	dxyz[0] = x/Grid.hx - Ix0; dxyz[1] = y/Grid.hy - Iy0; dxyz[2] = z/Grid.hz - Iz0;
+	dxyz[0] = (x-Grid.bounds[0])/Grid.hx - Ix0;
+	dxyz[1] = (y-Grid.bounds[2])/Grid.hy - Iy0;
+	dxyz[1] = (z-Grid.bounds[4])/Grid.hz - Iz0;
 
 	//warping, compute projection needed to map onto L.x/L.y domain, add 1 for negative values to accommodate sign
 	I_w[0] = Ix0/Grid.NX - (Ix0 < 0); I_w[1] = Iy0/Grid.NY - (Iy0 < 0);

--- a/Cuda-CMM/src/numerical/cmm-particles.h
+++ b/Cuda-CMM/src/numerical/cmm-particles.h
@@ -20,7 +20,7 @@
 
 #ifdef __CUDACC__
 
-	__global__ void k_rescale(int Nb_particle, double particles_center_x, double particles_center_y, double particles_width_x, double particles_width_y, double *particles_pos, double LX, double LY);
+	__global__ void k_rescale(int Nb_particle, double *particles_pos, TCudaGrid2D Grid);
 
 
 	__global__ void Particle_advect_inertia_init(int Nb_particle, double *particles_pos, double *particles_vel,

--- a/Cuda-CMM/src/simulation/cmm-euler2d.cu
+++ b/Cuda-CMM/src/simulation/cmm-euler2d.cu
@@ -51,7 +51,8 @@ void cuda_euler_2d(SettingsCMM& SettingsMain)
 	*						 	 Constants							   *
 	*******************************************************************/
 	
-	double bounds[6] = {0, twoPI, 0, twoPI, 0, 0};						// boundary information for translating
+	// boundary information for translating, 6 coords for 3D - (x0, x1, y0, y1, z0, z1)
+	double bounds[6] = {0, twoPI, 0, twoPI, 0, 0};
 	double t0 = SettingsMain.getRestartTime();							// time - initial
 	double dt;															// time - step final
 	int iterMax;														// time - maximum iteration count for safety
@@ -471,8 +472,8 @@ void cuda_euler_2d(SettingsCMM& SettingsMain)
 			cudaMalloc((void**) &Dev_forward_particles_pos[i_p], 2*particles_forwarded[i_p].num*sizeof(double));
 			mb_used_RAM_GPU += 2*particles_forwarded[i_p].num*sizeof(double) / 1e6;
 
-			// initialize particle position with 1 as forward particle type for parameters
-			init_particles(Dev_forward_particles_pos[i_p], SettingsMain, forward_particles_thread, forward_particles_block[i_p], bounds, 1, i_p);
+			// initialize particle position with 1 as forward particle type for parameters, Grid_psi for bounds
+			init_particles(Dev_forward_particles_pos[i_p], SettingsMain, forward_particles_thread, forward_particles_block[i_p], Grid_psi, 1, i_p);
 
 			// print some output to the Console
 			if (SettingsMain.getVerbose() >= 1) {
@@ -507,8 +508,8 @@ void cuda_euler_2d(SettingsCMM& SettingsMain)
 		cudaMalloc((void**) &Dev_particles_vel[i_p], (2*particles_advected[i_p].num*(particles_advected[i_p].tau != 0) + (particles_advected[i_p].tau == 0))*sizeof(double));
 		mb_used_RAM_GPU += 2*(1+particles_advected[i_p].tau != 0)*particles_advected[i_p].num*sizeof(double) / 1e6;
 
-		// initialize particle position with 0 as advected particle type for parameters
-		init_particles(Dev_particles_pos[i_p], SettingsMain, particle_thread, particle_block[i_p], bounds, 0, i_p);
+		// initialize particle position with 0 as advected particle type for parameters, Grid_psi for bounds
+		init_particles(Dev_particles_pos[i_p], SettingsMain, particle_thread, particle_block[i_p], Grid_psi, 0, i_p);
 
 		// print some output to the Console
 		if (SettingsMain.getVerbose() >= 1) {
@@ -797,8 +798,7 @@ void cuda_euler_2d(SettingsCMM& SettingsMain)
 			Map_Stack, Map_Stack_f, Grid_sample, Grid_discrete, Dev_Temp_2,
 			cufft_plan_sample_D2Z, cufft_plan_sample_Z2D, Dev_Temp_C1,
 			Host_forward_particles_pos, Dev_forward_particles_pos, forward_particles_block, forward_particles_thread,
-			Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f,
-			bounds, Dev_W_H_initial);
+			Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f, Dev_W_H_initial);
 	if (SettingsMain.getVerbose() >= 3 && message != "") {
 		std::cout<<message; logger.push(message);
 	}
@@ -1063,8 +1063,7 @@ void cuda_euler_2d(SettingsCMM& SettingsMain)
 				Map_Stack, Map_Stack_f, Grid_sample, Grid_discrete, Dev_Temp_2,
 				cufft_plan_sample_D2Z, cufft_plan_sample_Z2D, Dev_Temp_C1,
 				Host_forward_particles_pos, Dev_forward_particles_pos, forward_particles_block, forward_particles_thread,
-				Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f,
-				bounds, Dev_W_H_initial);
+				Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f, Dev_W_H_initial);
 		if (SettingsMain.getVerbose() >= 3 && message != "") {
 			std::cout<<message; logger.push(message);
 		}
@@ -1164,7 +1163,7 @@ void cuda_euler_2d(SettingsCMM& SettingsMain)
 		// initialize particle position
 		for (int i_p = 0; i_p < SettingsMain.getParticlesAdvectedNum(); ++i_p) {
 
-			init_particles(Dev_particles_pos[i_p], SettingsMain, particle_thread, particle_block[i_p], bounds, 0, i_p);
+			init_particles(Dev_particles_pos[i_p], SettingsMain, particle_thread, particle_block[i_p], Grid_psi, 0, i_p);
 
 			// initialize particle velocity for inertial particles
 	    	if (particles_advected[i_p].tau != 0) {
@@ -1234,8 +1233,7 @@ void cuda_euler_2d(SettingsCMM& SettingsMain)
 			Map_Stack, Map_Stack_f, Grid_sample, Grid_discrete, Dev_Temp_2,
 			cufft_plan_sample_D2Z, cufft_plan_sample_Z2D, Dev_Temp_C1,
 			Host_forward_particles_pos, Dev_forward_particles_pos, forward_particles_block, forward_particles_thread,
-			Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f,
-			bounds, Dev_W_H_initial);
+			Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f, Dev_W_H_initial);
 	if (SettingsMain.getVerbose() >= 3 && message != "") {
 		std::cout<<message; logger.push(message);
 	}

--- a/Cuda-CMM/src/simulation/cmm-init.h
+++ b/Cuda-CMM/src/simulation/cmm-init.h
@@ -29,12 +29,9 @@ __device__ double d_init_distirbution_function(double x, double v, int simulatio
 
 // initial condition for particles
 __host__ void init_particles(double* Dev_particles_pos, SettingsCMM SettingsMain,
-		int particle_thread, int particle_block, double* domain_bounds, int particle_type, int i_p);
-__global__ void k_part_init_circle(double* Dev_particles_pos, int particle_num,
-		double circle_center_x, double circle_center_y, double circle_radius_x, double circle_radius_y);
-__global__ void k_part_init_uniform_grid(double* Dev_particles_pos, int particle_num,
-		double square_center_x, double square_center_y, double square_radius_x, double square_radius_y);
-__global__ void k_part_init_sine_sheets(double* Dev_particles_pos, int particle_num,
-		double offset_x, double offset_y, double empty_x, double empty_y);
+		int particle_thread, int particle_block, TCudaGrid2D Grid, int particle_type, int i_p);
+__global__ void k_part_init_circle(int particle_num, double* Dev_particles_pos, TCudaGrid2D Grid);
+__global__ void k_part_init_uniform_grid(int particle_num, double* Dev_particles_pos, TCudaGrid2D Grid);
+__global__ void k_part_init_sine_sheets(int particle_num, double* Dev_particles_pos, TCudaGrid2D Grid);
 
 #endif

--- a/Cuda-CMM/src/simulation/cmm-simulation-host.cu
+++ b/Cuda-CMM/src/simulation/cmm-simulation-host.cu
@@ -572,8 +572,7 @@ std::string sample_compute_and_write(SettingsCMM SettingsMain, double t_now, dou
 		MapStack Map_Stack, MapStack Map_Stack_f, TCudaGrid2D* Grid_sample, TCudaGrid2D Grid_discrete, double *Dev_sample,
 		cufftHandle* cufft_plan_sample_D2Z, cufftHandle* cufft_plan_sample_Z2D, cufftDoubleComplex *Dev_Temp_C1,
 		double **Host_forward_particles_pos, double **Dev_forward_particles_pos, int *forward_particles_block, int forward_particles_thread,
-		double *Dev_ChiX, double *Dev_ChiY, double *Dev_ChiX_f, double *Dev_ChiY_f,
-		double *bounds, double *W_initial_discrete) {
+		double *Dev_ChiX, double *Dev_ChiY, double *Dev_ChiX_f, double *Dev_ChiY_f, double *W_initial_discrete) {
 
 	// check if we want to save at this time, combine all variables if so
 	std::string message = "";

--- a/Cuda-CMM/src/simulation/cmm-simulation-host.h
+++ b/Cuda-CMM/src/simulation/cmm-simulation-host.h
@@ -84,8 +84,7 @@ std::string sample_compute_and_write(SettingsCMM SettingsMain, double t_now, dou
 		MapStack Map_Stack, MapStack Map_Stack_f, TCudaGrid2D* Grid_sample, TCudaGrid2D Grid_discrete, double *Dev_sample,
 		cufftHandle* cufft_plan_sample_D2Z, cufftHandle* cufft_plan_sample_Z2D, cufftDoubleComplex *Dev_Temp_C1,
 		double **Host_forward_particles_pos, double **Dev_forward_particles_pos, int* forward_particles_block, int forward_particles_thread,
-		double *Dev_ChiX, double *Dev_ChiY, double *Dev_ChiX_f, double *Dev_ChiY_f,
-		double *bounds, double *W_initial_discrete);
+		double *Dev_ChiX, double *Dev_ChiY, double *Dev_ChiX_f, double *Dev_ChiY_f, double *W_initial_discrete);
 
 // sample vorticity with mapstack at arbitrary frame
 std::string Zoom(SettingsCMM SettingsMain, double t_now, double dt_now, double dt,

--- a/Cuda-CMM/src/simulation/cmm-simulation-kernel.cu
+++ b/Cuda-CMM/src/simulation/cmm-simulation-kernel.cu
@@ -314,9 +314,9 @@ __global__ void k_h_sample_map_compact(double *ChiX, double *ChiY, double *x_y, 
 
 	device_diffeo_interpolate_2D(ChiX, ChiY, x, y, &x, &y, Grid_map);
 
-	// save in two points in array
-	x_y[2*In  ] = Grid_map.bounds[0] + x - floor(x / LX) * LX;
-	x_y[2*In+1] = Grid_map.bounds[2] + y - floor(y / LY) * LY;
+	// save in two points in array and warp - translate by domain size(s)
+	x_y[2*In  ] = x - floor((x - Grid_map.bounds[0]) / LX) * LX;
+	x_y[2*In+1] = y - floor((y - Grid_map.bounds[2]) / LY) * LY;
 }
 // apply intermediate maps to compacted map, basically only samples in stacked form
 __global__ void k_apply_map_compact(double *ChiX_stack, double *ChiY_stack, double *x_y, TCudaGrid2D Grid_map, TCudaGrid2D Grid)
@@ -331,8 +331,9 @@ __global__ void k_apply_map_compact(double *ChiX_stack, double *ChiY_stack, doub
 	double LX = Grid_map.bounds[1] - Grid_map.bounds[0]; double LY = Grid_map.bounds[3] - Grid_map.bounds[2];
 	device_diffeo_interpolate_2D(ChiX_stack, ChiY_stack, x_y[2*In], x_y[2*In+1], &points[0], &points[1], Grid_map);
 
-	x_y[2*In] = Grid_map.bounds[0] + points[0] - floor(points[0]/LX)*LX;
-	x_y[2*In+1] = Grid_map.bounds[2] + points[1] - floor(points[1]/LY)*LY;
+	// warping - translate by domain size(s)
+	x_y[2*In  ] = points[0] - floor((points[0] - Grid_map.bounds[0])/LX)*LX;
+	x_y[2*In+1] = points[1] - floor((points[1] - Grid_map.bounds[2])/LY)*LY;
 }
 // sample from initial condition
 __global__ void k_h_sample_from_init(double *Val_out, double *x_y, TCudaGrid2D Grid, TCudaGrid2D Grid_discrete, int init_var_num, int init_num, double *Val_initial_discrete, bool initial_discrete)

--- a/Cuda-CMM/src/simulation/cmm-vlasov1d.cu
+++ b/Cuda-CMM/src/simulation/cmm-vlasov1d.cu
@@ -54,7 +54,8 @@ void cuda_vlasov_1d(SettingsCMM& SettingsMain)
 	*						 	 Constants							   *
 	*******************************************************************/
 	
-	double bounds[6] = {0, 10*twoPI, -8, 8, 0, 0};						// boundary information for translating
+	// boundary information for translating, 6 coords for 3D - (x0, x1, y0, y1, z0, z1)
+	double bounds[6] = {0, 10*twoPI, -8, 8, 0, 0};
 	// the code seems to work only square domains!!! is it a bug of a feature? I think its sad
 	double t0 = SettingsMain.getRestartTime();							// time - initial
 	double dt;															// time - step final
@@ -489,7 +490,7 @@ void cuda_vlasov_1d(SettingsCMM& SettingsMain)
 			mb_used_RAM_GPU += 2*particles_forwarded[i_p].num*sizeof(double) / 1e6;
 
 			// initialize particle position with 1 as forward particle type for parameters
-			init_particles(Dev_forward_particles_pos[i_p], SettingsMain, forward_particles_thread, forward_particles_block[i_p], bounds, 1, i_p);
+			init_particles(Dev_forward_particles_pos[i_p], SettingsMain, forward_particles_thread, forward_particles_block[i_p], Grid_psi, 1, i_p);
 
 			// print some output to the Console
 			if (SettingsMain.getVerbose() >= 1) {
@@ -525,7 +526,7 @@ void cuda_vlasov_1d(SettingsCMM& SettingsMain)
 		mb_used_RAM_GPU += 2*(1+particles_advected[i_p].tau != 0)*particles_advected[i_p].num*sizeof(double) / 1e6;
 
 		// initialize particle position with 0 as advected particle type for parameters
-		init_particles(Dev_particles_pos[i_p], SettingsMain, particle_thread, particle_block[i_p], bounds, 0, i_p);
+		init_particles(Dev_particles_pos[i_p], SettingsMain, particle_thread, particle_block[i_p], Grid_psi, 0, i_p);
 
 		// print some output to the Console
 		if (SettingsMain.getVerbose() >= 1) {
@@ -810,8 +811,7 @@ void cuda_vlasov_1d(SettingsCMM& SettingsMain)
 			Map_Stack, Map_Stack_f, Grid_sample, Grid_discrete, Dev_Temp_2,
 			cufft_plan_sample_D2Z, cufft_plan_sample_Z2D, Dev_Temp_C1,
 			Host_forward_particles_pos, Dev_forward_particles_pos, forward_particles_block, forward_particles_thread,
-			Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f,
-			bounds, Dev_W_H_initial);
+			Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f, Dev_W_H_initial);
 
 	// output status to console
 	if (SettingsMain.getVerbose() >= 3) {
@@ -1077,8 +1077,7 @@ void cuda_vlasov_1d(SettingsCMM& SettingsMain)
 				Map_Stack, Map_Stack_f, Grid_sample, Grid_discrete, Dev_Temp_2,
 				cufft_plan_sample_D2Z, cufft_plan_sample_Z2D, Dev_Temp_C1,
 				Host_forward_particles_pos, Dev_forward_particles_pos, forward_particles_block, forward_particles_thread,
-				Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f,
-				bounds, Dev_W_H_initial);
+				Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f, Dev_W_H_initial);
 		// output sample mesure status to console
 		if (SettingsMain.getVerbose() >= 3 && message != "") {
 			std::cout<<message+"\n"; logger.push(message);
@@ -1178,7 +1177,7 @@ void cuda_vlasov_1d(SettingsCMM& SettingsMain)
 		// initialize particle position
 		for (int i_p = 0; i_p < SettingsMain.getParticlesAdvectedNum(); ++i_p) {
 
-			init_particles(Dev_particles_pos[i_p], SettingsMain, particle_thread, particle_block[i_p], bounds, 0, i_p);
+			init_particles(Dev_particles_pos[i_p], SettingsMain, particle_thread, particle_block[i_p], Grid_psi, 0, i_p);
 
 			// initialize particle velocity for inertial particles
 	    	if (particles_advected[i_p].tau != 0) {
@@ -1246,8 +1245,7 @@ void cuda_vlasov_1d(SettingsCMM& SettingsMain)
 			Map_Stack, Map_Stack_f, Grid_sample, Grid_discrete, Dev_Temp_2,
 			cufft_plan_sample_D2Z, cufft_plan_sample_Z2D, Dev_Temp_C1,
 			Host_forward_particles_pos, Dev_forward_particles_pos, forward_particles_block, forward_particles_thread,
-			Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f,
-			bounds, Dev_W_H_initial);
+			Dev_ChiX, Dev_ChiY, Dev_ChiX_f, Dev_ChiY_f, Dev_W_H_initial);
 	// output sample mesure status to console
 	if (SettingsMain.getVerbose() >= 3 && message != "") {
 		std::cout<<message+"\n"; logger.push(message);


### PR DESCRIPTION
- Changed all warping occurences to correctly feature the domain begin
- This works by first shifting the position by domain begin in order to determine the correct amount of domain sizes to be warped
- occurences changed in particles, hermite and map sampling
- reordered particle initialization, this now uses Grid_psi to determine the map (as particles depend solely on velocity, chosen arbitrarily though)